### PR TITLE
Recover macos continuous integration to Java8; Add check-license as continuous integration dependent job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         java:
           - {
             version: 8,
@@ -91,6 +91,36 @@ jobs:
           - {
             version: 17,
             maven_args: "-Dmaven.javadoc.skip=true"
+          }
+    steps:
+      - name: Cache Maven Repos
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java.version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java.version }}
+      - name: Build with Maven
+        run: echo y | ./mvnw -B clean install ${{ matrix.java.maven_args }}
+      - name: Build examples with Maven
+        run: echo y | ./mvnw -B -f examples/pom.xml clean package -DskipTests
+
+  macos:
+    name: CI Tests - JDK ${{ matrix.java.version }} - on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest ]
+        java:
+          - {
+            version: 8,
+            maven_args: "cobertura:cobertura -Dmaven.javadoc.skip=true"
           }
     steps:
       - name: Cache Maven Repos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         uses: apache/skywalking-eyes@main
         
   windows:
+    needs: check-license
     runs-on: windows-latest
     steps:
       - name: Cache Maven Repos
@@ -74,6 +75,7 @@ jobs:
   
   unix:
     name: CI Tests - JDK ${{ matrix.java.version }} - on ${{ matrix.os }}
+    needs: check-license
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -112,6 +114,7 @@ jobs:
 
   macos:
     name: CI Tests - JDK ${{ matrix.java.version }} - on ${{ matrix.os }}
+    needs: check-license
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Test GitHub CI on forked repository